### PR TITLE
Add functions to destroy, like, unlike, retweet and unretweet a tweet

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    twitty (0.1.0)
+    twitty (0.1.2)
       oauth
 
 GEM

--- a/lib/twitty/constants.rb
+++ b/lib/twitty/constants.rb
@@ -61,7 +61,37 @@ module Twitty
         method: :post,
         endpoint: '/oauth/access_token',
         required_params: [:oauth_token, :oauth_verifier]
+      },
+
+      destroy_tweet: {
+        method: :post,
+        endpoint: '/1.1/statuses/destroy/%{tweet_id}.json',
+        required_params: [:tweet_id]
+      },
+
+      retweet: {
+        method: :post,
+        endpoint: '/1.1/statuses/retweet/%{tweet_id}.json',
+        required_params: [:tweet_id]
+      },
+
+      unretweet: {
+        method: :post,
+        endpoint: '/1.1/statuses/unretweet/%{tweet_id}.json',
+        required_params: [:tweet_id]
+      },
+
+      like_tweet: {
+        method: :post,
+        endpoint: '/1.1/favorites/create.json',
+        required_params: [:tweet_id]
+      },
+
+      unlike_tweet: {
+        method: :post,
+        endpoint: '/1.1/favorites/destroy.json',
+        required_params: [:tweet_id]
       }
-  }.freeze
+    }.freeze
   end
 end

--- a/lib/twitty/payload.rb
+++ b/lib/twitty/payload.rb
@@ -1,6 +1,9 @@
+# frozen_string_literal: true
+
 module Twitty
   module Payload
-    EMPTY_PAYLOAD_ACTIONS = %w[fetch_webhooks register_webhook unregister_webhook fetch_subscriptions create_subscription remove_subscription].freeze
+    EMPTY_PAYLOAD_ACTIONS = %w[fetch_webhooks register_webhook unregister_webhook fetch_subscriptions
+                               create_subscription remove_subscription destroy_tweet retweet unretweet].freeze
 
     EMPTY_PAYLOAD_ACTIONS.each do |action|
       define_method "#{action.to_s}_payload" do
@@ -46,6 +49,18 @@ module Twitty
       {
         oauth_token: @payload[:oauth_token],
         oauth_verifier: @payload[:oauth_verifier]
+      }
+    end
+
+    def like_tweet_payload
+      {
+        "id": @payload[:tweet_id]
+      }
+    end
+
+    def unlike_tweet_payload
+      {
+        "id": @payload[:tweet_id]
       }
     end
   end

--- a/lib/twitty/version.rb
+++ b/lib/twitty/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Twitty
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end


### PR DESCRIPTION

- $twitter.destroy_tweet(tweet_id: "tweet_id_number") will destroy the tweet that
  you secretly knew deep down in your heart that you should never have tweeted in the first place.
- $twitter.like_tweet(tweet_id: "tweet_id_number") will like the tweet that bought a smile to your face.
- $twitter.unlike_tweet(tweet_id: "tweet_id_number") a secret tool to get yourself out of deepfaving.
- $twitter.retweet(tweet_id: "tweet_id_number") and $twitter.retweet(tweet_id: "tweet_id_number") does
  exactly what it says on the tin.

Resolve: #16